### PR TITLE
[Fix] rag 초기화

### DIFF
--- a/database_migration.sql
+++ b/database_migration.sql
@@ -121,14 +121,14 @@ ORDER BY table_name;
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );
 
-  2. communication_guidelines 테이블 수정
+  -- 2. communication_guidelines 테이블 수정
 
-  벡터 임베딩 관련 컬럼 추가:
+  -- 벡터 임베딩 관련 컬럼 추가:
   ALTER TABLE communication_guidelines
   ADD COLUMN vector_embeddings JSONB,
   ADD COLUMN chunk_metadata JSONB;
 
-  3. 동적 쿼리 관련 테이블 추가
+  -- 3. 동적 쿼리 관련 테이블 추가
 
   -- 쿼리 분석 결과 저장
   CREATE TABLE query_analysis_results (

--- a/python_backend/agents/quality_analysis_agent.py
+++ b/python_backend/agents/quality_analysis_agent.py
@@ -124,6 +124,10 @@ class OptimizedEnterpriseQualityAgent(BaseAgent):
             protocol_suggestions=[]
         )
     
+    def _get_default_config(self) -> OptimizedEnterpriseQualityConfig:
+        """기본 설정 반환"""
+        return OptimizedEnterpriseQualityConfig()
+    
     async def _load_company_data(self, state: OptimizedEnterpriseQualityState) -> OptimizedEnterpriseQualityState:
         """기업 데이터 로딩 (기존과 동일)"""
         async with self._step_context("기업 데이터 로딩", state):

--- a/python_backend/core/config.py
+++ b/python_backend/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
         return f"http://{self.FINETUNE_INFERENCE_HOST}:{self.FINETUNE_INFERENCE_PORT}"
     
     # OpenAI 설정
-    OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+    OPENAI_API_KEY: str = ""
     OPENAI_MODEL: str = "gpt-4o"
     
     # 데이터베이스 설정
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     CORS_HEADERS: list = ["*"]
     
     class Config:
-        env_file = ".env"  # 현재 디렉토리의 .env 파일 참조
+        env_file = Path(__file__).resolve().parent.parent / ".env"  # 프로젝트 루트의 .env 파일 참조
         case_sensitive = True
         extra = "ignore"
 

--- a/python_backend/core/rag_config.py
+++ b/python_backend/core/rag_config.py
@@ -18,8 +18,8 @@ class RAGConfig:
     """RAG 관련 경로/모델/청킹 설정을 제공"""
 
     # 단일 회사(stand-alone) 기준 고정 경로
-    faiss_index_path: Path = Path("python_backend/langchain_pipeline/data/faiss_index")
-    documents_path: Path = Path("python_backend/langchain_pipeline/data/documents")
+    faiss_index_path: Path = Path("langchain_pipeline/data/faiss_index")
+    documents_path: Path = Path("langchain_pipeline/data/documents")
 
     # 임베딩/청킹 설정
     _embedding_model: str = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
@@ -55,11 +55,7 @@ class RAGConfig:
         """OpenAI API 키를 환경에서 조회(없으면 None)"""
         from core.config import get_settings
         settings = get_settings()
-        api_key = (
-            os.getenv("OPENAI_API_KEY")
-            or getattr(settings, "OPENAI_API_KEY", "")
-            or None
-        )
+        api_key = getattr(settings, "OPENAI_API_KEY", "") or None
         if api_key and api_key.startswith("sk-"):
             return api_key
         return None

--- a/python_backend/langchain_pipeline/embedder/gpt_embedder.py
+++ b/python_backend/langchain_pipeline/embedder/gpt_embedder.py
@@ -35,18 +35,21 @@ class GPTTextEmbedder:
     def _initialize_client(self):
         """OpenAI 클라이언트 초기화"""
         try:
-            # .env 파일에서 API 키 로드
-            dotenv_path = Path(__file__).resolve().parents[3] / ".env"
-            if dotenv_path.exists():
-                from dotenv import load_dotenv
-                load_dotenv(dotenv_path=dotenv_path)
-            
             from core.config import get_settings
             settings = get_settings()
+            api_key = settings.OPENAI_API_KEY
+
+            if not api_key or not api_key.startswith("sk-"):
+                logger.warning("OpenAI API 키가 유효하지 않습니다. OpenAI 클라이언트를 초기화할 수 없습니다.")
+                self.client = None
+                return
+
+            self.client = OpenAI(api_key=api_key)
+            logger.info("OpenAI 클라이언트 초기화 성공")
+
         except Exception as e:
             logger.error(f"OpenAI 클라이언트 초기화 실패: {e}")
-            return
-    api_key = settings.OPENAI_API_KEY
+            self.client = None
 
     def _get_embedding(self, text: str) -> Optional[List[float]]:
         """텍스트의 GPT 임베딩 생성"""

--- a/python_backend/langchain_pipeline/retriever/vector_db.py
+++ b/python_backend/langchain_pipeline/retriever/vector_db.py
@@ -225,7 +225,7 @@ def load_vector_store(load_path: Path) -> Optional[FAISS]:
             vectorstore = FAISS.load_local(
                 str(load_path),
                 embeddings,
-                allow_dangerous_deserialization=False
+                allow_dangerous_deserialization=True
             )
         except Exception as security_error:
             logger.warning(f"안전한 역직렬화 실패, 신뢰된 경로 재시도: {security_error}")

--- a/python_backend/services/rag_service.py
+++ b/python_backend/services/rag_service.py
@@ -91,7 +91,7 @@ class RAGService:
                 return
             
             # 새로 생성
-            docs_path = Path("python_backend/langchain_pipeline/data/documents")
+            docs_path = Path("langchain_pipeline/data/documents")
             if create_embeddings_from_documents(docs_path) and self.simple_embedder.load():
                 logger.info("Simple Text Embedder 생성 및 로드 완료")
             else:
@@ -105,7 +105,7 @@ class RAGService:
     def _load_documents(self) -> list:
         """문서 로드 공통 함수"""
         from pathlib import Path
-        docs_path = Path("python_backend/langchain_pipeline/data/documents")
+        docs_path = Path("langchain_pipeline/data/documents")
         documents = []
         
         if not docs_path.exists():


### PR DESCRIPTION
1. rag 초기화
최신 langchain 버전에서 FAISS 인덱스를 로드할 때 보안 위험을 방지하기 위해 allow_dangerous_deserialization 플래그가 존재
allow_dangerous_deserialization=False
-> 기본값인 False는 안전하지만, 구버전 LangChain으로 생성된 인덱스를 로드하지 못하는 문제가 발생

- 문제 상황
팀원 중 누군가가 구버전 LangChain으로 만든 인덱스가 남아있다면, 최신 버전으로 업데이트한 다른 팀원은 그 인덱스를 로드하지 못하고 에러 남
allow_dangerous_deserialization=True로 임시 변경
---
 2. openai key 로드 경로 재설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when loading the vector store with a safe fallback for trusted project paths.
  - More robust OpenAI client initialization with clear warnings if the API key is missing or invalid.

- Chores
  - Configuration now reads from the project root .env; environment variables for the API key are no longer auto-read.
  - Updated default locations for indexes and documents; ensure files are placed in the new paths.
  - Database migration headings converted to comments (no behavioral change).
  - Internal cleanup to centralize default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->